### PR TITLE
Added remove-all-metrics function. 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+## Changes Between 2.4.0 and 2.5.0
+
+### Added remove-all-metrics function
+
+`metrics-clojure` Now has a function to remove all existing metrics from a given registry.
+
+Contributed by Jason Whitlark.
+
 ## Changes Between 2.3.0 and 2.4.0
 
 ### Metrics 3.1.0

--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -35,6 +35,14 @@
   ([^MetricRegistry reg title]
    (.remove reg (metric-name title))))
 
+(defn remove-all-metrics
+  "Remove all the metrics in the given registry, or the default
+  registry if no registry given."
+  ([] (remove-all-metrics default-registry))
+  ([^MetricRegistry reg]
+   (doseq [metric (.getNames reg)]
+     (.remove reg metric))))
+
 (defn replace-metric
   "Replace a metric with the given title."
   ([title ^Metric metric]


### PR DESCRIPTION
It's necessary (but not sufficient) if you want to cleanly shut down a metric-registry, say, during testing.
