### PR TITLE
Bump version of io.dropwizard.metrics/metrics-* to 3.1.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+## Changes Between 2.4.0 and 2.5.0
+
+### Metrics 3.1.1
+
+`metrics-clojure` is now based on [Metrics 3.1.1](https://github.com/dropwizard/metrics/issues/694#issuecomment-77668929).
+
 ## Changes Between 2.3.0 and 2.4.0
 
 ### Metrics 3.1.0

--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -1,7 +1,7 @@
 (defproject metrics-clojure "2.5.0-SNAPSHOT"
   :description "A Clojure façade for Coda Hale's metrics library."
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.dropwizard.metrics/metrics-core "3.1.0"]]
+                 [io.dropwizard.metrics/metrics-core "3.1.1"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"
                  ;; to get Clojure snapshots
                  "sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"

--- a/metrics-clojure-ganglia/project.clj
+++ b/metrics-clojure-ganglia/project.clj
@@ -1,4 +1,4 @@
 (defproject metrics-clojure-ganglia "2.5.0-SNAPSHOT"
   :description "Ganglia reporter integration for metrics-clojure"
   :dependencies [[metrics-clojure "2.5.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-ganglia "3.1.0"]])
+                 [io.dropwizard.metrics/metrics-ganglia "3.1.1"]])

--- a/metrics-clojure-graphite/project.clj
+++ b/metrics-clojure-graphite/project.clj
@@ -1,4 +1,4 @@
 (defproject metrics-clojure-graphite "2.5.0-SNAPSHOT"
   :description "Graphite reporter integration for metrics-clojure"
   :dependencies [[metrics-clojure "2.5.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-graphite "3.1.0"]])
+                 [io.dropwizard.metrics/metrics-graphite "3.1.1"]])

--- a/metrics-clojure-health/project.clj
+++ b/metrics-clojure-health/project.clj
@@ -1,4 +1,4 @@
 (defproject metrics-clojure-health "2.5.0-SNAPSHOT"
   :description "Gluing together metrics-clojure and healthchecks."
   :dependencies [[metrics-clojure "2.5.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-healthchecks "3.1.0"]])
+                 [io.dropwizard.metrics/metrics-healthchecks "3.1.1"]])

--- a/metrics-clojure-jvm/project.clj
+++ b/metrics-clojure-jvm/project.clj
@@ -1,4 +1,4 @@
 (defproject metrics-clojure-jvm "2.5.0-SNAPSHOT"
   :description "Gluing together metrics-clojure and jvm instrumentation."
   :dependencies [[metrics-clojure "2.5.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-jvm "3.1.0"]])
+                 [io.dropwizard.metrics/metrics-jvm "3.1.1"]])


### PR DESCRIPTION
I ran the tests in core.  I have not run it in production, but don't see any issues with doing so.  This should correct #63, as it pulls in the version 3.1.1, which doesn't have that regression.