### PR TITLE
Fully qualify return types in metrics-clojure-core

### DIFF
--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -58,7 +58,7 @@
   [^Timer m]
   (.getMeanRate m))
 
-(defn ^long number-recorded
+(defn ^clojure.core$long number-recorded
   [^Timer t]
   (.getCount t))
 
@@ -112,7 +112,7 @@
 (defn start
   "Start a timer, returning the context object that will be used to
   stop this particular instance."
-  ^Timer$Context [^Timer t]
+  ^com.codahale.metrics.Timer$Context [^Timer t]
   (.time t))
 
 (defn stop


### PR DESCRIPTION
Fixes #66.  There were bad tags only in core.

I'd like to see a new version released, mainly so I can pick up the switch to 3.1.1.  Does #65 need to be closed for that to happen?