### PR TITLE
Added remove-all-metrics function. It's necessary (but not sufficient)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Changes Between 2.4.0 and 2.5.0
 
+### Added remove-all-metrics function
+
+`metrics-clojure` Now has a function to remove all existing metrics from a given registry.
+
 ### Metrics 3.1.1
 
 `metrics-clojure` is now based on [Metrics 3.1.1](https://github.com/dropwizard/metrics/issues/694#issuecomment-77668929).

--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -35,6 +35,14 @@
   ([^MetricRegistry reg title]
    (.remove reg (metric-name title))))
 
+(defn remove-all-metrics
+  "Remove all the metrics in the given registry, or the default
+  registry if no registry given."
+  ([] (remove-all-metrics default-registry))
+  ([^MetricRegistry reg]
+   (doseq [metric (.getNames reg)]
+     (.remove reg metric))))
+
 (defn replace-metric
   "Replace a metric with the given title."
   ([title ^Metric metric]


### PR DESCRIPTION
if you want to cleanly shut down a metric-registry, during testing.