### PR TITLE
Add timing function using start and stop.

### DIFF
--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -120,3 +120,10 @@
   was returned when it was started."
   [^Timer$Context tc]
   (.stop tc))
+
+(defmacro start-stop-time!
+  [^Timer t & body]
+  `(let [^Timer$Context start# (start ~t)
+         out# (do ~@body)]
+     (metrics.timers/stop start#)
+     out#))

--- a/metrics-clojure-core/test/metrics/test/timers_test.clj
+++ b/metrics-clojure-core/test/metrics/test/timers_test.clj
@@ -62,3 +62,34 @@
     (is (= (mt/time! t (sleep-100)) 100))
     (Thread/sleep expiration-delay)
     (is (> (mt/rate-fifteen t) 0.0))))
+
+(deftest test-rate-mean-start-stop
+  (let [r (mc/new-registry)
+        t (mt/timer r ["test" "timers" "test-rate-mean"])]
+    (is (= (mt/rate-mean t) 0.0))
+    (is (= (mt/start-stop-time! t (sleep-100)) 100))
+    (is (> (mt/rate-mean t) 0.0))))
+
+(deftest test-rate-one-start-stop
+  (let [r (mc/new-registry)
+        t (mt/timer r ["test" "timers" "test-rate-one"])]
+    (is (= (mt/rate-one t) 0.0))
+    (is (= (mt/start-stop-time! t (sleep-100)) 100))
+    (Thread/sleep expiration-delay)
+    (is (> (mt/rate-one t) 0.0))))
+
+(deftest test-rate-five-start-stop
+  (let [r (mc/new-registry)
+        t (mt/timer r ["test" "timers" "test-rate-five"])]
+    (is (= (mt/rate-five t) 0.0))
+    (is (= (mt/start-stop-time! t (sleep-100)) 100))
+    (Thread/sleep expiration-delay)
+    (is (> (mt/rate-five t) 0.0))))
+
+(deftest test-rate-fifteen-start-stop
+  (let [r (mc/new-registry)
+        t (mt/timer r ["test" "timers" "test-rate-fifteen"])]
+    (is (= (mt/rate-fifteen t) 0.0))
+    (is (= (mt/start-stop-time! t (sleep-100)) 100))
+    (Thread/sleep expiration-delay)
+    (is (> (mt/rate-fifteen t) 0.0))))


### PR DESCRIPTION
This function is necessary to time code inside async/go! blocks because it doesn't wrap the code in a callable like timers/time! or timers/time-fn!. 

I wanted to add a test that showed this functionality but wasn't sure what your opinion on adding a dependency to core.async is. Let me know, I'm happy to add it.
