### PR TITLE
Fix typo in riemann reporter.

### DIFF
--- a/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
+++ b/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
@@ -29,7 +29,7 @@
     :host-name     - Override source host name
     :tags          - collection of tags to attach to event"
   ([riemann opts]
-   (reporter riemann-client default-registry opts))
+   (reporter riemann default-registry opts))
   ([riemann registry {:keys [clock
                              prefix
                              rate-unit


### PR DESCRIPTION
Previous PR had a typo, apologies.