### PR TITLE
bump cheshire version to 5.5.0

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -2,6 +2,6 @@
   :description "Various things gluing together metrics-clojure and ring."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
-  :dependencies [[cheshire "5.3.1"]
+  :dependencies [[cheshire "5.5.0"]
                  [metrics-clojure "2.6.0-SNAPSHOT"]]
   :profiles {:dev {:dependencies [[ring "1.3.0"]]}})


### PR DESCRIPTION
This PR bumps Cheshire version (latest stable) in metrics-clojure-ring.