### PR TITLE
Add `core/remove-metrics` to remove metrics matching a given predicate

### DIFF
--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -35,13 +35,21 @@
   ([^MetricRegistry reg title]
    (.remove reg (metric-name title))))
 
+(defn remove-metrics
+  "Remove all the metrics matching the given predicate in the given
+  repository, or the default registry if no registry given. The
+  predicate takes one argument, the name of the metric."
+  ([pred] (remove-metrics default-registry pred))
+  ([^MetricRegistry reg pred]
+   (doseq [metric (.getNames reg)]
+     (when (pred metric) (.remove reg metric)))))
+
 (defn remove-all-metrics
   "Remove all the metrics in the given registry, or the default
   registry if no registry given."
   ([] (remove-all-metrics default-registry))
   ([^MetricRegistry reg]
-   (doseq [metric (.getNames reg)]
-     (.remove reg metric))))
+   (remove-metrics reg (constantly true))))
 
 (defn replace-metric
   "Replace a metric with the given title."


### PR DESCRIPTION
The predicate is provided with a name and should return true or false if
the metric has to be removed.

Fix #81

No test is provided as there is none currently. I would have added some but I don't know how to add a metric without using metrics defined outside core.