### PR TITLE
core/gauges: add a `gauge` method to retrieve an existing gauge

### DIFF
--- a/docs/source/metrics/gauges.rst
+++ b/docs/source/metrics/gauges.rst
@@ -19,11 +19,14 @@ Creating
 Create your gauge using ``gauge-fn``::
 but you have to pass it a function, not just a body::
 
-    (require '[metrics.gauges :refer [gauge-fn]])
+    (require '[metrics.gauges :refer [gauge-fn gauge]])
 
     (def files-open
       (gauge-fn "files-open"
              #(return-number-of-files-open ...)))
+
+Once a gauge has been registered, a call to ``(gauge "files-open")`` will
+return the existing gauge.
 
 .. _gauges/defgauge:
 

--- a/metrics-clojure-core/src/metrics/gauges.clj
+++ b/metrics-clojure-core/src/metrics/gauges.clj
@@ -1,7 +1,7 @@
 (ns metrics.gauges
   (:require [metrics.core :refer [default-registry metric-name]]
             [metrics.utils :refer [desugared-title]])
-  (:import [com.codahale.metrics MetricRegistry Gauge]
+  (:import [com.codahale.metrics MetricRegistry MetricFilter Gauge]
            clojure.lang.IFn))
 
 (defn gauge-fn
@@ -18,6 +18,17 @@
          s (metric-name title)]
      (.remove reg s)
      (.register reg s g))))
+
+(defn gauge
+  "Retrieve an existing gauge from the provided registry (or the
+  default registry) from its name. Returns nil when not found."
+  ([title]
+   (gauge default-registry title))
+  ([^MetricRegistry reg title]
+   (when-let [matches (seq (.getGauges reg (reify MetricFilter
+                                             (matches [this name _]
+                                               (= name (metric-name title))))))]
+     (val (first matches)))))
 
 
 (defmacro defgauge

--- a/metrics-clojure-core/test/metrics/test/gauges_test.clj
+++ b/metrics-clojure-core/test/metrics/test/gauges_test.clj
@@ -14,3 +14,12 @@
         g (gauges/gauge-fn ["test" "gauges" "test-gauge-fn"]
                            #(+ 100 2))]
     (is (= (gauges/value g) 102))))
+
+(deftest test-gauge
+  (let [r (mc/new-registry)
+        g (gauges/gauge-fn ["test" "gauges" "test-gauge"]
+                           #(+ 100 3))
+        g2 (gauges/gauge ["test" "gauges" "test-gauge"])
+        g3 (gauges/gauge ["test" "gauges" "test-gauge-not"])]
+    (is (= (gauges/value g2) 103))
+    (is (= g3 nil))))


### PR DESCRIPTION
Unlike other types, it was not possible to retrieve a gauge from a
registry unless a direct reference was kept. A new `gauge` function will
allow to retrieve (but not define) an existing gauge from its name or
return nil.

This closes #83.

If you don't mind, I'll also do a PR to make the documentation use a registry in the gauge example to match all other types.