### PR TITLE
docs: metrics-clojure-healthchecks is metrics-clojure-health

### DIFF
--- a/docs/source/healthchecks.rst
+++ b/docs/source/healthchecks.rst
@@ -1,7 +1,7 @@
 HealthChecks
 ============
 
-``metrics-clojure-healthchecks`` will allow you to define and run healthcheck.
+``metrics-clojure-health`` will allow you to define and run healthcheck.
 
 example
 -------


### PR DESCRIPTION
The documentation mentions metrics-clojure-healthchecks while this
really is metrics-clojure-health.