### PR TITLE
health: allow to specify a vector for metric title

### DIFF
--- a/metrics-clojure-health/src/metrics/health/core.clj
+++ b/metrics-clojure-health/src/metrics/health/core.clj
@@ -38,10 +38,11 @@
   ([title ^IFn hc-fn]
      (healthcheck-fn default-healthcheck-registry title hc-fn))
   ([^HealthCheckRegistry reg title ^IFn hc-fn]
-     (let [hc (new-hc hc-fn)]
+     (let [hc (new-hc hc-fn)
+           s (metric-name title)]
        ;; REVIEW: Should this automatically remove a previous check of
        ;; the same title? (jw 14-08-28)
-       (.register reg title hc)
+       (.register reg s hc)
        hc)))
 
 (defmacro defhealthcheck


### PR DESCRIPTION
Like for other types, ensure `health-fn` allows a vector as a metric title.

The change is trivial but I was not able to test it as I am not familiar on how to run `lein repl` when it's unable to grab a dependency (`metrics-clojure:2.6.0-SNAPSHOT`). Can I teach it to use the neighbor directory instead?