### PR TITLE
ring: add a method to render metrics as maps

### DIFF
--- a/metrics-clojure-ring/src/metrics/ring/expose.clj
+++ b/metrics-clojure-ring/src/metrics/ring/expose.clj
@@ -82,13 +82,19 @@
 ;; API
 ;;
 
+(defn render-metrics
+  ([]
+   (render-metrics default-registry))
+  ([registry]
+   (into {} (map render-metric (all-metrics registry)))))
+
 (defn serve-metrics
   ([request]
      (serve-metrics request default-registry))
   ([request registry]
      (serve-metrics request registry false))
   ([request registry {:keys [pretty-print?] :as opts}]
-     (let [metrics-map (into {} (map render-metric (all-metrics registry)))
+     (let [metrics-map (render-metrics registry)
            json        (generate-string metrics-map {:pretty pretty-print?})]
        (-> (response json)
          (header "Content-Type" "application/json")))))


### PR DESCRIPTION
This map can then be transformed to JSON or to any other exportable
structure. This makes integration of a /metrics endpoint more natural
when using some frameworks (for example, compojure-api).

Again, unable to test as I don't know how to compile with dependencies in adjacent directories. But since it's quite simple, I am confident that it would work just fine. :)