### PR TITLE
update dependencies

### DIFF
--- a/metrics-clojure-riemann/project.clj
+++ b/metrics-clojure-riemann/project.clj
@@ -3,4 +3,4 @@
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
   :dependencies [[metrics-clojure "2.7.0-SNAPSHOT"]
-                 [com.aphyr/riemann-java-client "0.3.1"]])
+                 [com.aphyr/metrics3-riemann-reporter "0.4.1"]])

--- a/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
+++ b/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
@@ -1,6 +1,5 @@
 (ns metrics.reporters.riemann
-  (:require [metrics.core :refer [default-registry]]
-            [com.stuartsierra.component :as component])
+  (:require [metrics.core :refer [default-registry]])
   (:import [java.util.concurrent TimeUnit]
            [com.codahale.metrics.riemann Riemann RiemannReporter RiemannReporter$Builder]
            [com.aphyr.riemann.client IRiemannClient]))


### PR DESCRIPTION
This makes it easier to mix metrics-clojure and relying on a recent riemann-clojure-client.