### PR TITLE
Update docs for metrics-clojure, metrics-clojure-health

### DIFF
--- a/docs/source/healthchecks.rst
+++ b/docs/source/healthchecks.rst
@@ -3,7 +3,16 @@ HealthChecks
 
 ``metrics-clojure-health`` will allow you to define and run healthcheck.
 
-example
+Install
+-------
+
+``metrics-clojure-health`` is provided as a separate package from ``metrics.core``.
+To install add the following to your ``project.clj``::
+
+    [metrics-clojure-health "2.6.1"]
+
+
+Example
 -------
 
 An example using the default HealthCheckRegistry, (which is different

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,6 +3,6 @@ Installation
 
 Add this to your ``project.clj``'s dependencies::
 
-    [metrics-clojure "2.6.0"]
+    [metrics-clojure "2.6.1"]
 
 That's it.


### PR DESCRIPTION
- Bumps the version number for `metrics-clojure` to 2.6.1
- Adds a directive to the `metrics-clojure-health` docs that
  explicitly states that this package must be installed in order
  to use the health checks

Thanks!