### PR TITLE
Fixed hardcoded metrics-clojure-ring version in docs

### DIFF
--- a/docs/source/ring.rst
+++ b/docs/source/ring.rst
@@ -10,9 +10,11 @@ Installation
 The extra Ring-related functionality is in a separate ``metrics-clojure-ring``
 library so you don't have to install it unless you want it.
 
-To install it, add this to your ``project.clj``'s dependencies::
+To install it, add this to your ``project.clj``'s dependencies:
 
-    [metrics-clojure-ring "2.0.0"]
+.. parsed-literal::
+
+    [metrics-clojure-ring "|release|"]
 
 **Note:** the versions of metrics-clojure and metrics-clojure-ring should always
 be the same.


### PR DESCRIPTION
Wanted to use this awesome looking library, but ran into a small annoyance with the docs.

Unfortunately I didn't pay attention to the ** Note: **, but I was used to c/ping from everywhere else in the docs :) 