### PR TITLE
Added custom reservoir support

### DIFF
--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -1,5 +1,8 @@
 (ns metrics.core
-  (:import [com.codahale.metrics MetricRegistry Metric]))
+  (:import [com.codahale.metrics MetricRegistry Metric
+            UniformReservoir ExponentiallyDecayingReservoir
+            SlidingWindowReservoir SlidingTimeWindowReservoir]
+           [java.util.concurrent TimeUnit]))
 
 (def ^{:tag MetricRegistry :doc "Default registry used by public API functions when no explicit registry argument is given"}
   default-registry
@@ -83,3 +86,33 @@
   "Returns a map of all the counters in the registry and their names."
   [^MetricRegistry reg]
   (.getCounters reg))
+
+(defn uniform-reservior
+  "Create a uniform reservior, which uses Vitter's Algorithm R to
+  produce a statistically representative sample. Default size: 1028."
+  ([]
+   (UniformReservoir.))
+  ([size]
+   (UniformReservoir. size)))
+
+(defn exponentially-decaying-reservoir
+  "Create an exponentially decaying reservior, which uses Cormode et al's
+  forward-decaying priority reservoir sampling method to produce a
+  statistically representative sampling reservoir, exponentially biased
+  towards newer entries. Default size: 1028, alpha 0.015"
+  ([]
+   (ExponentiallyDecayingReservoir.))
+  ([size alpha]
+   (ExponentiallyDecayingReservoir. size alpha)))
+
+(defn sliding-time-window-reservoir
+  "Create a reservior backed by a sliding window that stores only the
+  measurements made in the last N seconds"
+  [window ^TimeUnit unit]
+  (SlidingTimeWindowReservoir. window unit))
+
+(defn sliding-window-reservoir
+  "Create a reservior backed by a sliding window that stores the last
+  N measurements."
+  [size]
+  (SlidingWindowReservoir. size))

--- a/metrics-clojure-core/src/metrics/histograms.clj
+++ b/metrics-clojure-core/src/metrics/histograms.clj
@@ -1,7 +1,7 @@
 (ns metrics.histograms
   (:require [metrics.core :refer [default-registry metric-name]]
             [metrics.utils :refer [get-percentiles desugared-title snapshot]])
-  (:import [com.codahale.metrics MetricRegistry Histogram Snapshot]))
+  (:import [com.codahale.metrics MetricRegistry Histogram Snapshot Reservoir]))
 
 
 (defn histogram
@@ -16,6 +16,13 @@
   ([^MetricRegistry reg title]
    (.histogram reg (metric-name title))))
 
+(defn histogram-with-reservoir
+  "Create histogram with a custom reservoir. If a Histogram already exists with
+  given title, this function will throw IllegalArgumentException."
+  [^MetricRegistry reg ^Reservoir reservoir title]
+  (let [metric (Histogram. reservoir)]
+    (.register ^MetricRegistry reg title metric)
+    metric))
 
 (defmacro defhistogram
   "Define a Histogram metric with the given title.

--- a/metrics-clojure-core/test/metrics/test/timers_test.clj
+++ b/metrics-clojure-core/test/metrics/test/timers_test.clj
@@ -93,3 +93,14 @@
     (is (= (mt/start-stop-time! t (sleep-100)) 100))
     (Thread/sleep expiration-delay)
     (is (> (mt/rate-fifteen t) 0.0))))
+
+(deftest test-timer-with-reservoir
+  (let [r (mc/new-registry)
+        s (mc/sliding-window-reservoir 1000)]
+    (mt/timer-with-reservoir r s "timer")
+    (try
+      (mt/timer-with-reservoir r s "timer")
+      (is false)
+      (catch IllegalArgumentException _
+        (is true)))
+    (is (some? (mt/timer r"timer")))))


### PR DESCRIPTION
Reservoir as an important feature is missing in current metrics-clojure. It allows histogram based metrics (histogram and timer) to drop some data based on custom strategy (uniform, sliding window, etc). This is helpful when we want to collect timer for last minute, for example.

The bad part is upstream API doesn't provide entry point for custom reservoir in `MetricRegistry`, so there is no way to use this feature with `MetricRegistry`'s get-or-add API. Duplicated creation will lead to `IllegalArgumentException`. So I created new function for timer and histogram.

@michaelklishin @sjl PTAL