### PR TITLE
Bump Cheshire version to 5.7.0

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -4,4 +4,5 @@
   :license {:name "MIT"}
   :dependencies [[cheshire "5.7.0"]
                  [metrics-clojure "2.9.0-SNAPSHOT"]]
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[ring "1.4.0"]]}})

--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -2,6 +2,6 @@
   :description "Various things gluing together metrics-clojure and ring."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
-  :dependencies [[cheshire "5.5.0"]
+  :dependencies [[cheshire "5.7.0"]
                  [metrics-clojure "2.9.0-SNAPSHOT"]]
   :profiles {:dev {:dependencies [[ring "1.4.0"]]}})


### PR DESCRIPTION
This small PR just bumps the Cheshire version and enables reflection warning in the build file (following `metrics-clojure-core/project.clj`).