### PR TITLE
Prevent all reflection across the library.

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -15,6 +15,7 @@
     :profiles {:1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
                :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
                :1.9    {:dependencies [[org.clojure/clojure "1.9.0-alpha4"]]}
-               :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+               :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}
+               :dev    {:global-vars {*warn-on-reflection* true}}}
   :aliases  {"all" ["with-profile" "+dev:+1.6:+1.7:+1.9:+master"]}
   :global-vars {*warn-on-reflection* true})

--- a/metrics-clojure-ganglia/project.clj
+++ b/metrics-clojure-ganglia/project.clj
@@ -2,5 +2,6 @@
   :description "Ganglia reporter integration for metrics-clojure"
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [io.dropwizard.metrics/metrics-ganglia "3.1.2"]])

--- a/metrics-clojure-ganglia/src/metrics/reporters/ganglia.clj
+++ b/metrics-clojure-ganglia/src/metrics/reporters/ganglia.clj
@@ -3,14 +3,15 @@
   (:require [metrics.core  :refer [default-registry]]
             [metrics.reporters :as mrep])
   (:import java.util.concurrent.TimeUnit
+           info.ganglia.gmetric4j.gmetric.GMetric
            [com.codahale.metrics MetricRegistry MetricFilter]
            [com.codahale.metrics.ganglia GangliaReporter GangliaReporter$Builder]))
 
 (defn ^com.codahale.metrics.ganglia.GangliaReporter reporter
   ([ganglia opts]
      (reporter default-registry ganglia opts))
-  ([^MetricRegistry reg ganglia {:keys [rate-unit duration-unit filter] :as opts}]
-     (let [b (GangliaReporter/forRegistry reg)]
+  ([^MetricRegistry reg ^GMetric ganglia {:keys [rate-unit duration-unit filter] :as opts}]
+     (let [b ^GangliaReporter$Builder (GangliaReporter/forRegistry reg)]
        (when-let [^TimeUnit ru rate-unit]
          (.convertRatesTo b ru))
        (when-let [^TimeUnit du duration-unit]

--- a/metrics-clojure-graphite/project.clj
+++ b/metrics-clojure-graphite/project.clj
@@ -2,5 +2,6 @@
   :description "Graphite reporter integration for metrics-clojure"
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [io.dropwizard.metrics/metrics-graphite "3.1.2"]])

--- a/metrics-clojure-graphite/src/metrics/reporters/graphite.clj
+++ b/metrics-clojure-graphite/src/metrics/reporters/graphite.clj
@@ -7,17 +7,25 @@
            [com.codahale.metrics Metric MetricRegistry Clock MetricFilter]
            [com.codahale.metrics.graphite Graphite GraphiteReporter GraphiteReporter$Builder]))
 
+(defn- ^InetSocketAddress inet-socket-address
+  [^String hostname ^Long port]
+  (InetSocketAddress. hostname (int port)))
+
+(defn- ^GraphiteReporter$Builder builder-for-registry
+  [^MetricRegistry reg]
+  (GraphiteReporter/forRegistry reg))
+
+(defn- ^Graphite graphite-sender
+  [hostname port]
+  (Graphite. (inet-socket-address hostname (int port))))
 
 (defn ^com.codahale.metrics.graphite.GraphiteReporter reporter
   ([opts]
      (reporter default-registry opts))
   ([^MetricRegistry reg {:keys [host hostname port prefix clock rate-unit duration-unit filter] :as opts
                          :or {port 2003}}]
-     (let [g (Graphite. (InetSocketAddress. (or host
-                                                hostname
-                                                "localhost")
-                                            port))
-           b (GraphiteReporter/forRegistry reg)]
+     (let [g (graphite-sender (or host hostname "localhost") port)
+           b (builder-for-registry reg)]
        (when-let [^String s prefix]
          (.prefixedWith b s))
        (when-let [^Clock c clock]

--- a/metrics-clojure-health/project.clj
+++ b/metrics-clojure-health/project.clj
@@ -1,6 +1,7 @@
 (defproject metrics-clojure-health "2.9.0-SNAPSHOT"
   :description "Gluing together metrics-clojure and healthchecks."
   :url "https://github.com/sjl/metrics-clojure"
-  :license {:name "MIT"}  
+  :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]])

--- a/metrics-clojure-health/src/metrics/health/core.clj
+++ b/metrics-clojure-health/src/metrics/health/core.clj
@@ -19,7 +19,7 @@
 (defn unhealthy
   "Returns a unhealthy result."
   ([^String message & args]
-     (HealthCheck$Result/unhealthy (apply format message args))))
+     (HealthCheck$Result/unhealthy ^String (apply format message args))))
 
 (defn new-hc
   "Wrap a fn to ensure it returns healthy/unhealthy. Any exception or
@@ -70,7 +70,7 @@
 (defn check
   "Run a given HealthCheck."
   [^HealthCheck h]
-  (.check ^HealthCheck h))
+  (.execute h))
 
 (defn check-all
   "Returns a map with the keys :healthy & :unhealthy, each containing

--- a/metrics-clojure-influxdb/project.clj
+++ b/metrics-clojure-influxdb/project.clj
@@ -2,5 +2,6 @@
   :description "InfluxDB reporter integration for metrics-clojure"
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [com.izettle/dropwizard-metrics-influxdb "1.1.6"]])

--- a/metrics-clojure-influxdb/src/metrics/reporters/influxdb.clj
+++ b/metrics-clojure-influxdb/src/metrics/reporters/influxdb.clj
@@ -32,7 +32,7 @@
      (when read-timeout
        (.setConnectTimeout b read-timeout))
      (when group-guages
-       (.setGroupGuages b group-guages))
+       (.setGroupGauges b group-guages))
      (when-let [^TimeUnit du duration-unit]
        (.setPrecision b du))
      (when-let [^java.util.Map mm measurement-mappings]

--- a/metrics-clojure-jvm/project.clj
+++ b/metrics-clojure-jvm/project.clj
@@ -2,5 +2,6 @@
   :description "Gluing together metrics-clojure and jvm instrumentation."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [io.dropwizard.metrics/metrics-jvm "3.1.2"]])

--- a/metrics-clojure-riemann/project.clj
+++ b/metrics-clojure-riemann/project.clj
@@ -2,5 +2,6 @@
   :description "Riemann reporter integration for metrics-clojure"
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.9.0-SNAPSHOT"]
                  [com.aphyr/metrics3-riemann-reporter "0.4.1"]])

--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -4,5 +4,5 @@
   :license {:name "MIT"}
   :dependencies [[cheshire "5.7.0"]
                  [metrics-clojure "2.9.0-SNAPSHOT"]]
-  :global-vars {*warn-on-reflection* true}
-  :profiles {:dev {:dependencies [[ring "1.4.0"]]}})
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}
+                   :dependencies [[ring "1.4.0"]]}})


### PR DESCRIPTION
- Standardize on `*warn-on-reflection*` to `true` for the dev profile
- Fix `metrics.health.core/check` (previously called protected method `check` instead of `execute`).
- Fix `metrics.reporters.influxdb` (previously called `setGuages` instead of `setGauges`)