### PR TITLE
Upgrade iZettle influx library for fewer transitive dependencies

### DIFF
--- a/metrics-clojure-influxdb/project.clj
+++ b/metrics-clojure-influxdb/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.10.0-SNAPSHOT"]
-                 [com.izettle/dropwizard-metrics-influxdb "1.1.6"]])
+                 [com.izettle/dropwizard-metrics-influxdb "1.1.8"]])


### PR DESCRIPTION
Version 1.1.6 has a very large list of transitive dependencies as it depends on dropwizard-core. Version 1.1.8 has solved this problem by depending specifically on dropwizard-metrics.

See https://github.com/iZettle/dropwizard-metrics-influxdb/pull/57