### PR TITLE
update to 3.2.2, eliminate reflection warning

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]]
+                 [io.dropwizard.metrics/metrics-core "3.2.2"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"
                  ;; to get Clojure snapshots
                  "sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"

--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -117,7 +117,7 @@
 
 (defn time-fn!
   [^Timer t ^clojure.lang.IFn f]
-  (.time t (cast Callable f)))
+  (.time t (reify Callable (call [this] (f)))))
 
 (defn start
   "Start a timer, returning the context object that will be used to

--- a/metrics-clojure-ganglia/project.clj
+++ b/metrics-clojure-ganglia/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.10.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-ganglia "3.1.2"]])
+                 [io.dropwizard.metrics/metrics-ganglia "3.2.2"]])

--- a/metrics-clojure-graphite/project.clj
+++ b/metrics-clojure-graphite/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.10.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]])
+                 [io.dropwizard.metrics/metrics-graphite "3.2.2"]])

--- a/metrics-clojure-health/project.clj
+++ b/metrics-clojure-health/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.10.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]])
+                 [io.dropwizard.metrics/metrics-healthchecks "3.2.2"]])

--- a/metrics-clojure-jvm/project.clj
+++ b/metrics-clojure-jvm/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "2.10.0-SNAPSHOT"]
-                 [io.dropwizard.metrics/metrics-jvm "3.1.2"]])
+                 [io.dropwizard.metrics/metrics-jvm "3.2.2"]])


### PR DESCRIPTION
After updating to 3.2.2 a reflection warning appeared. Reflection warning, metrics/timers.clj:120:3 - call to method time on com.codahale.metrics.Timer can't be resolved (argument types: unknown).
The reason is that in codahale metrics, Timer now has 2 methods for  time.  One accepts a Runnable and the other accepts a Callable.  Since clojure functions implement both, it cannot decide which to use.  I resolved the issue by using reify Callable.  Hopefully the performance penalty is not too great, especially since this concerns the time-fn! method.   

There is an existing unit test that for time-fn! that passes, so at least we know it still works. 