### PR TITLE
Allow graphite/reporter to take existing Graphite instance

### DIFF
--- a/docs/source/aggregation.rst
+++ b/docs/source/aggregation.rst
@@ -37,6 +37,7 @@ ten seconds.
 
 Optional arguments to graphite/reporter are:
 
+- :graphite
 - :host
 - :port
 - :prefix
@@ -44,6 +45,11 @@ Optional arguments to graphite/reporter are:
 - :rate-unit
 - :duration-unit
 - :filter
+
+Note: The :graphite argument allows an existing ``com.codahale.metrics.graphite.Graphite``
+instance to be specified. If specified, this instance will be used rather than a new
+instance constructed using the :host and :port arguments. This is useful if you need
+to supply a specially-constructed Graphite instance.
 
 Sending Metrics to Ganglia
 --------------------------

--- a/metrics-clojure-graphite/src/metrics/reporters/graphite.clj
+++ b/metrics-clojure-graphite/src/metrics/reporters/graphite.clj
@@ -22,9 +22,10 @@
 (defn ^com.codahale.metrics.graphite.GraphiteReporter reporter
   ([opts]
      (reporter default-registry opts))
-  ([^MetricRegistry reg {:keys [host hostname port prefix clock rate-unit duration-unit filter] :as opts
+  ([^MetricRegistry reg {:keys [graphite host hostname port prefix clock rate-unit duration-unit filter] :as opts
                          :or {port 2003}}]
-     (let [g (graphite-sender (or host hostname "localhost") port)
+     (let [g (or graphite
+                 (graphite-sender (or host hostname "localhost") port))
            b (builder-for-registry reg)]
        (when-let [^String s prefix]
          (.prefixedWith b s))


### PR DESCRIPTION
...rather than resolving (hostname, port) to `InetSocketAddress` *once*.

We've been using this library in production for a few months, and it's been working great. But every few weeks, we noticed _some_ of our applications would stop reporting to Graphite: `Unable to report to Graphite`. Once this condition was reached, the affected apps would not report to Graphite until being restarted. We were able to time-correlate these incidents with AWS recycling IP addresses in the ELB that fronts our Graphite instances.

The issue seems to be that `graphite-sender` resolves `hostname` to a particular IP address, and uses the [`Graphite` constructor](https://github.com/dropwizard/metrics/blob/3.2-development/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java#L78) that accepts a `InetSocketAddress`. When the IPs behind a hostname change over time, that IP address may no longer be valid but will never be _re-resolved_ by the `Graphite` reporter.

It appears [this code in `Graphite.connect()`](https://github.com/dropwizard/metrics/blob/3.2-development/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java#L113-L116) will never re-resolve the IP address if `Graphite` was instantiated with the `InetSocketAddress` constructor, since `this.address == null` will never be `true`, and `address.getAddress()` doesn't re-resolve the IP address from the `hostname` if it's already been resolved once.

My proposed fix is to use the `Graphite` constructor that takes the same arguments as `graphite-sender`: `hostname` and `port`.