### PR TITLE
Ring: JSON filtering of metrics

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -2,7 +2,7 @@
   :description "Various things gluing together metrics-clojure and ring."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
-  :dependencies [[cheshire "5.7.0"]
+  :dependencies [[cheshire "5.7.1"]
                  [metrics-clojure "2.10.0-SNAPSHOT"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[ring "1.4.0"]

--- a/metrics-clojure-ring/src/metrics/ring/expose.clj
+++ b/metrics-clojure-ring/src/metrics/ring/expose.clj
@@ -81,17 +81,17 @@
 (defn- placeholder? [c]
   (#{"" "*"} c))
 
-(defn- filter-matches? [kn filter]
+;;
+;; API
+;;
+
+(defn filter-matches? [kn filter]
   (every? identity
           (map (fn [k f]
                  (or (placeholder? f)
                      (= k f)))
                (string/split kn #"\.")
                (string/split filter #"\."))))
-
-;;
-;; API
-;;
 
 (defn filter-metrics [^String filter metrics]
   (if (string/blank? filter)

--- a/metrics-clojure-ring/test/metrics/test/expose_test.clj
+++ b/metrics-clojure-ring/test/metrics/test/expose_test.clj
@@ -1,10 +1,30 @@
 (ns metrics.test.expose-test
   (:require [clojure.test :refer :all]
-            [metrics.ring.expose :refer [expose-metrics-as-json]])
+            [metrics.ring.expose :refer [filter-matches? expose-metrics-as-json]])
   (:import [com.codahale.metrics MetricRegistry]))
 
 (deftest test-expose-metrics-as-json
   ;; Ensure that ring.expose compiles
   (expose-metrics-as-json (constantly nil)))
 
+(deftest test-filter-matches?
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.requests-scheme")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.*")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring..")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "*.requests-scheme")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" ".requests-scheme")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.*.rate")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring..rate")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.*.*.https")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.*.rate.*")))
+  (is (true? (filter-matches? "ring.requests-scheme.rate.https" "ring.requests-scheme.rate.https")))
+  ;;
+  (is (false? (filter-matches? "ring.requests-scheme.rate.https" "RING")))
+  (is (false? (filter-matches? "ring.requests-scheme.rate.https" "RING.requests-scheme")))
+  (is (false? (filter-matches? "ring.requests-scheme.rate.https" "..requests-scheme")))
+  (is (false? (filter-matches? "ring.requests-scheme.rate.https" "ring.*.https")))
 
+  )


### PR DESCRIPTION
Enable simple filtering of the JSON exposed metrics. The filter parameter allows specifying a filter string for matching the metrics name groups (delimited by the dot character). The asterisk character is interpreted as "match all" (as syntactic sugar the asterisk can also be left out).

Examples:

* Show only ring.requests metrics: `...?filter=ring.requests`
* Show only ring rates: `...?filter=ring.*.rate or ...?filter=ring..rate`

By merging the filter parameter into the the handler opts parameter it is also possible to create an endpoint exposing only a fixed set of metrics, e.g. the above ring rates:

Compojure routes:

```
(def app
  (-> (routes home-routes app-routes)
      (wrap-base-url)
      (expose-metrics-as-json "/admin/stats/" default-registry {:filter "ring.*.rate"})))
```