### PR TITLE
bump Cheshire dependency version to 5.8.0

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -2,7 +2,7 @@
   :description "Various things gluing together metrics-clojure and ring."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
-  :dependencies [[cheshire "5.7.1"]
+  :dependencies [[cheshire "5.8.0"]
                  [metrics-clojure "2.10.0-SNAPSHOT"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[ring "1.4.0"]


### PR DESCRIPTION
This PR bumps Cheshire version to the latest stable `5.8.0`.