### PR TITLE
Include 50th percentile in histogram and timer

### DIFF
--- a/metrics-clojure-core/src/metrics/histograms.clj
+++ b/metrics-clojure-core/src/metrics/histograms.clj
@@ -72,9 +72,9 @@
   * 100% were less than or equal to 500
 
   If you don't pass a list of desired percentiles, the default will be
-  [0.75 0.95 0.99 0.999 1.0]."
+  [0.5 0.75 0.95 0.99 0.999 1.0]."
   ([^Histogram h]
-   (percentiles h [0.75 0.95 0.99 0.999 1.0]))
+   (percentiles h [0.5 0.75 0.95 0.99 0.999 1.0]))
   ([^Histogram h ps]
    (get-percentiles h ps)))
 

--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -90,7 +90,7 @@
 (defn percentiles
   "Returns timing percentiles seen by a timer, in nanoseconds"
   ([^Timer t]
-   (percentiles t [0.75 0.95 0.99 0.999 1.0]))
+   (percentiles t [0.5 0.75 0.95 0.99 0.999 1.0]))
   ([^Timer t ps]
    (get-percentiles t ps)))
 


### PR DESCRIPTION
Align the range of reported percentile values (JSON report from the Ring middleware) to the values returned by the core reporters e.g. JMX or Console.