### PR TITLE
Fix number-recorded type hint

### DIFF
--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -68,7 +68,7 @@
   [^Timer m]
   (.getMeanRate m))
 
-(defn ^long number-recorded
+(defn number-recorded ^long
   [^Timer t]
   (.getCount t))
 

--- a/metrics-clojure-core/test/metrics/test/timers_test.clj
+++ b/metrics-clojure-core/test/metrics/test/timers_test.clj
@@ -104,3 +104,11 @@
       (catch IllegalArgumentException _
         (is true)))
     (is (some? (mt/timer r"timer")))))
+
+(deftest test-number-recorded-return-type
+  (let [r (mc/new-registry)
+        t (mt/timer r ["test" "timers" "test-num-recorded"])]
+    (binding [*warn-on-reflection* false]
+      (is (= java.lang.Long
+             (.getClass (mt/number-recorded t)))))))
+


### PR DESCRIPTION
The type hint for for function returns should go between the var name
and arguments. In the case of num-recorded, if you tried to do
arithmetic on the returned value, you'd get an Exception like:

`java.lang.IllegalArgumentException: Unable to resolve classname: clojure.core$long@6df773ef`

See https://dev.clojure.org/jira/browse/CLJ-1753 and
https://dev.clojure.org/jira/browse/CLJ-1674 for details.